### PR TITLE
ci: Labeler improvements

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,8 +5,10 @@
 name: "Pull Request Labeler"
 
 on:
-- pull_request_target
-- issue_comment
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
@@ -26,18 +28,35 @@ jobs:
         sync-labels: "" # This is a workaround for issue 18671
 
     - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
-      if: github.event_name == 'pull_request_target'
+      if: github.event_name == 'pull_request_target' && !github.event.pull_request.draft
       with:
         script: |
-          await github.rest.issues.addLabels({
+          labels = await github.rest.issues.listLabelsOnIssue({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            labels: ["please-review"]
-          })
+          });
+
+          good_to_merge = [
+            "good-to-merge/waiting-for-ci 👍",
+            "good-to-merge/after-next-release",
+            "good-to-merge/with-minor-suggestions",
+            "good-to-merge/waiting-for-reporter-feedback 👍",
+          ]
+
+          if (labels.every((l) => !good_to_merge.includes(l)))
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["please-review"]
+            })
+          }
+
           for (const label of ["reviewed/needs-rework 🔨",
                                "ci-fails/needs-rework 🔥",
-                               "ci-failure-appears-unrelated"]) {
+                               "ci-failure-appears-unrelated",
+                               "needs-rebase"]) {
             try {
               await github.rest.issues.removeLabel({
                 issue_number: context.issue.number,

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -41,6 +41,9 @@ See [reporting of security vulnerabilities](SECURITY.md).
 * After you have pushed a new version, add a comment explaining the latest changes. If you are a member of the systemd project on GitHub, remove the `reviewed/needs-rework`/`ci-fails/needs-rework`/`needs-rebase` labels.
 * If you are copying existing code from another source (eg: a compat header), please make sure the license is compatible with `LGPL-2.1-or-later`. If the license is not `LGPL-2.1-or-later`, please add a note to [`LICENSES/README.md`](https://github.com/systemd/systemd/blob/main/LICENSES/README.md).
 * If the pull request stalls without review, post a ping in a comment after some time has passed. We are always short on reviewer time, and pull requests which haven't seen any recent activity can be easily forgotten.
+* Github will automatically add the please-review label when a pull request is opened or updated. If you need
+more information after a review, you can comment `/please-review` on the pull request to have Github add the
+please-review to the pull request.
 
 ## Reviewing Pull Requests
 


### PR DESCRIPTION
- Mention "/please-review" in the contributing guide
- Remove "needs-rebase" on push
- Don't add "please-review" if a green label is set
- Don't add please-review label to draft PRs
- Add please-review when a PR moves out of draft