### PR TITLE
ci: Optimize pull request labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -52,38 +52,34 @@ jobs:
             repo: context.repo.repo,
           });
 
-          good_to_merge = [
+          original = new Set(response.data.map(l => l.name));
+          labels = new Set(original);
+
+          good_to_merge = new Set([
             "good-to-merge/waiting-for-ci 👍",
             "good-to-merge/after-next-release",
             "good-to-merge/with-minor-suggestions",
             "good-to-merge/waiting-for-reporter-feedback 👍",
-          ];
+          ]);
 
-          if (response.data.every(l => !good_to_merge.includes(l.name))) {
-            await github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ["please-review"]
-            });
+          if (labels.intersection(good_to_merge).size == 0) {
+            labels.add("please-review");
           }
 
           for (const label of ["reviewed/needs-rework 🔨",
                                "ci-fails/needs-rework 🔥",
                                "ci-failure-appears-unrelated",
                                "needs-rebase"]) {
-            try {
-              await github.rest.issues.removeLabel({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: label,
-              });
-            } catch (err) {
-              if (err.status != 404) {
-                throw err;
-              }
-            }
+            labels.delete(label);
+          }
+
+          if (labels.size != original.size || [...labels].some(l => !original.has(l))) {
+            response = await github.rest.issues.setLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: Array.from(labels).map(l => {"name": l}),
+            });
           }
 
     - name: Add please-review label on command in issue comment
@@ -103,6 +99,15 @@ jobs:
       if: startsWith(github.event_name, 'pull_request') && github.event.action == 'closed'
       with:
         script: |
+          response = await github.rest.issues.listLabelsOnIssue({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });
+
+          original = new Set(response.data.map(l => l.name));
+          labels = new Set(original);
+
           for (const label of ["please-review",
                                "reviewed/needs-rework 🔨",
                                "ci-fails/needs-rework 🔥",
@@ -116,16 +121,14 @@ jobs:
                                "dont-merge 💣",
                                "squash-on-merge",
                                "quick-review 🏃‍♂️"]) {
-            try {
-              await github.rest.issues.removeLabel({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: label,
-              });
-            } catch (err) {
-              if (err.status != 404) {
-                throw err;
-              }
-            }
+            labels.delete(label);
+          }
+
+          if (labels.size != original.size || [...labels].some(l => !original.has(l))) {
+            response = await github.rest.issues.setLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: Array.from(labels).map(l => {"name": l}),
+            });
           }


### PR DESCRIPTION
We keep running into rate limits, so let's optimize the number of requests we do in the pull request labeler to hopefully fix that.